### PR TITLE
[hotfix] 방 최신 정보 날짜 변경 및 1.0.3 업데이트

### DIFF
--- a/feature/src/main/java/com/dongguk/telepigeon/feature/main/main/MainFragment.kt
+++ b/feature/src/main/java/com/dongguk/telepigeon/feature/main/main/MainFragment.kt
@@ -74,7 +74,8 @@ class MainFragment : BindingFragment<FragmentMainBinding>({ FragmentMainBinding.
                             }
                             else -> MainType.WAITING
                         }?.let { mainType ->
-                            setHomeType(mainType = mainType, number = number)
+                            days?.let { days ->
+                                setHomeType(mainType = mainType, number = days) }
                         }
                     }
                 }

--- a/feature/src/main/java/com/dongguk/telepigeon/feature/main/main/MainFragment.kt
+++ b/feature/src/main/java/com/dongguk/telepigeon/feature/main/main/MainFragment.kt
@@ -75,7 +75,8 @@ class MainFragment : BindingFragment<FragmentMainBinding>({ FragmentMainBinding.
                             else -> MainType.WAITING
                         }?.let { mainType ->
                             days?.let { days ->
-                                setHomeType(mainType = mainType, number = days) }
+                                setHomeType(mainType = mainType, number = days)
+                            }
                         }
                     }
                 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,8 +2,8 @@
 compileSdk = "34"
 minSdk = "28"
 targetSdk = "34"
-versionCode = "7"
-versionName = "1.0.2"
+versionCode = "8"
+versionName = "1.0.3"
 
 # Kotlin
 agp = "8.1.4"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -26,7 +26,7 @@ navigation = "2.7.7"
 material = "1.12.0"
 google-services = "4.4.2"
 firebase-crashlytics = "3.0.2"
-firebase-bom = "33.1.2"
+firebase-bom = "33.2.0"
 
 # Test
 junit = "4.13.2"
@@ -47,7 +47,7 @@ activityVersion = "1.9.1"
 sentry = "4.1.1"
 kakao = "2.20.3"
 inject = "1"
-firebaseMessagingKtx = "24.0.0"
+firebaseMessagingKtx = "24.0.1"
 
 [libraries]
 # Kotlin


### PR DESCRIPTION
## Related issue 🛠
- closed #51 

## Work Description ✏️
- 방 최신 정보 뷰에서 날짜값이 이상하게 매핑되는 문제를 해결했습니다.
- 1.0.3 업데이트를 진행했습니다.

## Screenshot 📸
![Screenshot_20240830_113520](https://github.com/user-attachments/assets/98850d50-df98-402d-9990-8f55873de9d3)

## Uncompleted Tasks 😅
- N/A

## To Reviewers 📢
얘들아 미안 ㅜㅜ